### PR TITLE
[Feat] 환율 데이터 반환 API 구현 및 레디스 저장 로직 역할 경계 명시

### DIFF
--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/application/ExchangeRateSyncService.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/application/ExchangeRateSyncService.java
@@ -1,23 +1,18 @@
 package com.wanderpass.exchange_rate_service.exchange.application;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wanderpass.exchange_rate_service.exchange.application.dto.ExchangeRateResponse;
 import com.wanderpass.exchange_rate_service.exchange.domain.entity.ExchangeRate;
 import com.wanderpass.exchange_rate_service.exchange.domain.type.Currency;
 import com.wanderpass.exchange_rate_service.exchange.exception.exchange.ExchangeRateResponseEmptyException;
-import com.wanderpass.exchange_rate_service.exchange.exception.redis.RedisCacheException;
 import com.wanderpass.exchange_rate_service.exchange.infrastructure.client.ExchangeRateClient;
 import com.wanderpass.exchange_rate_service.exchange.infrastructure.persistence.ExchangeRateBatchRepository;
-import com.wanderpass.exchange_rate_service.exchange.infrastructure.persistence.ExchangeRateRepository;
 
+import com.wanderpass.exchange_rate_service.exchange.infrastructure.redis.ExchangeRateCacheRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,10 +24,8 @@ public class ExchangeRateSyncService {
 
     private final ExchangeRateClient client;
     private final ExchangeRateCalculator calculator;
-    private final ExchangeRateRepository exchangeRateRepository;
     private final ExchangeRateBatchRepository exchangeRateBatchRepository;
-    private final RedisTemplate<String, String> redisTemplate;
-    private final ObjectMapper objectMapper;
+    private final ExchangeRateCacheRepository exchangeRateCacheRepository;
 
     /**
      * 동기 방식으로 OpenAPI 호출 → 이후 로직은 트랜잭션이 보장되는 범위 내에서 처리
@@ -64,14 +57,6 @@ public class ExchangeRateSyncService {
     }
 
     private void cacheToRedis(Currency from, Currency to, BigDecimal rate, LocalDateTime fetchedAt) {
-        try {
-            String key = "exchange_rate:" + from + ":" + to;
-            String value = objectMapper.writeValueAsString(
-                    Map.of("rate", rate, "fetchedAt", fetchedAt.toString())
-            );
-            redisTemplate.opsForValue().set(key, value, Duration.ofHours(1));
-        } catch (JsonProcessingException e) {
-            throw new RedisCacheException("Redis 캐싱 실패");
-        }
+        exchangeRateCacheRepository.save(from, to, rate, fetchedAt);
     }
 }

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/application/ExchangeService.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/application/ExchangeService.java
@@ -2,7 +2,6 @@ package com.wanderpass.exchange_rate_service.exchange.application;
 
 import com.wanderpass.exchange_rate_service.exchange.domain.entity.ExchangeRate;
 import com.wanderpass.exchange_rate_service.exchange.domain.type.Currency;
-import com.wanderpass.exchange_rate_service.exchange.infrastructure.client.ExchangeRateClient;
 import com.wanderpass.exchange_rate_service.exchange.infrastructure.persistence.ExchangeRateRepository;
 import com.wanderpass.exchange_rate_service.exchange.infrastructure.redis.ExchangeRateCacheRepository;
 import com.wanderpass.exchange_rate_service.exchange.infrastructure.redis.ExchangeRateData;

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/application/ExchangeService.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/application/ExchangeService.java
@@ -1,0 +1,61 @@
+package com.wanderpass.exchange_rate_service.exchange.application;
+
+import com.wanderpass.exchange_rate_service.exchange.domain.entity.ExchangeRate;
+import com.wanderpass.exchange_rate_service.exchange.domain.type.Currency;
+import com.wanderpass.exchange_rate_service.exchange.infrastructure.client.ExchangeRateClient;
+import com.wanderpass.exchange_rate_service.exchange.infrastructure.persistence.ExchangeRateRepository;
+import com.wanderpass.exchange_rate_service.exchange.infrastructure.redis.ExchangeRateCacheRepository;
+import com.wanderpass.exchange_rate_service.exchange.infrastructure.redis.ExchangeRateData;
+import com.wanderpass.exchange_rate_service.exchange.presentation.dto.request.ConvertRequest;
+import com.wanderpass.exchange_rate_service.exchange.presentation.dto.response.ConvertResponse;
+import com.wanderpass.exchange_rate_service.global.exception.type.BusinessException;
+import com.wanderpass.exchange_rate_service.global.exception.type.StatusCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ExchangeService {
+    private final ExchangeRateCacheRepository exchangeRateCacheRepository;
+    private final ExchangeRateRepository exchangeRateRepository;
+
+    public ConvertResponse convert(ConvertRequest request) {
+        Currency from = request.fromCurrency();
+        Currency to = request.toCurrency();
+
+        ExchangeRateData cached = exchangeRateCacheRepository.get(from, to);
+
+        // fallback 처리를 위해서 null 반환을 처리해줘야한다.
+        if (cached == null) {
+            ExchangeRate rate = exchangeRateRepository
+                    .findTopByFromCurrencyAndToCurrencyOrderByFetchedAtDesc(from, to)
+                    .orElseThrow(() ->
+                            new BusinessException(StatusCode.NOT_FOUND, "레디스에 미존재하는 데이터를 MySQL에서 조회했지만 존재하지않는 환율 데이터입니다.")
+                    );
+            exchangeRateCacheRepository.save(from, to, rate.getRate(), rate.getFetchedAt());
+            cached = ExchangeRateData.builder()
+                    .rate(rate.getRate())
+                    .fetchedAt(rate.getFetchedAt())
+                    .build();
+        }
+
+        BigDecimal convertedAmount = BigDecimal.valueOf(request.amount())
+                .multiply(cached.getRate())
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return ConvertResponse.builder()
+                .requestId(request.requestId())
+                .fromCurrency(request.fromCurrency().name())
+                .toCurrency(request.toCurrency().name())
+                .rate(cached.getRate())
+                .convertedAmount(convertedAmount)
+                .fetchedAt(cached.getFetchedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/config/OpenExchangeProperties.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/config/OpenExchangeProperties.java
@@ -2,7 +2,6 @@ package com.wanderpass.exchange_rate_service.exchange.config;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/persistence/ExchangeRateRepository.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/persistence/ExchangeRateRepository.java
@@ -3,9 +3,7 @@ package com.wanderpass.exchange_rate_service.exchange.infrastructure.persistence
 import com.wanderpass.exchange_rate_service.exchange.domain.entity.ExchangeRate;
 import com.wanderpass.exchange_rate_service.exchange.domain.type.Currency;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ExchangeRateRepository extends JpaRepository<ExchangeRate, Long> {

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/persistence/ExchangeRateRepository.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/persistence/ExchangeRateRepository.java
@@ -1,6 +1,13 @@
 package com.wanderpass.exchange_rate_service.exchange.infrastructure.persistence;
 
 import com.wanderpass.exchange_rate_service.exchange.domain.entity.ExchangeRate;
+import com.wanderpass.exchange_rate_service.exchange.domain.type.Currency;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface ExchangeRateRepository extends JpaRepository<ExchangeRate, Long> {}
+import java.util.List;
+import java.util.Optional;
+
+public interface ExchangeRateRepository extends JpaRepository<ExchangeRate, Long> {
+    Optional<ExchangeRate> findTopByFromCurrencyAndToCurrencyOrderByFetchedAtDesc(Currency from, Currency to);
+}

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/redis/ExchangeRateCacheRepository.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/redis/ExchangeRateCacheRepository.java
@@ -1,0 +1,50 @@
+package com.wanderpass.exchange_rate_service.exchange.infrastructure.redis;
+
+import com.wanderpass.exchange_rate_service.exchange.domain.type.Currency;
+import com.wanderpass.exchange_rate_service.exchange.exception.redis.RedisCacheException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ExchangeRateCacheRepository {
+
+    private final RedisTemplate<String, ExchangeRateData> redisTemplate;
+
+    private static final Duration CACHE_TTL = Duration.ofHours(1);
+
+    public ExchangeRateData get(Currency from, Currency to) {
+        String key = createKey(from, to);
+        try {
+            return redisTemplate.opsForValue().get(key);
+        } catch (Exception e) {
+            log.warn("Redis 환율 조회 실패: key={}, error={}", key, e.getMessage());
+            return null;
+        }
+    }
+
+    public void save(Currency from, Currency to, BigDecimal rate, LocalDateTime fetchedAt) {
+        String key = createKey(from, to);
+        ExchangeRateData data = ExchangeRateData.builder()
+                .rate(rate)
+                .fetchedAt(fetchedAt)
+                .build();
+
+        try {
+            redisTemplate.opsForValue().set(key, data, CACHE_TTL);
+        } catch (Exception e) {
+            throw new RedisCacheException("Redis 캐싱 실패" + e);
+        }
+    }
+
+    private String createKey(Currency from, Currency to) {
+        return String.format("exchange_rate:%s:%s", from, to);
+    }
+}

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/redis/ExchangeRateData.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/redis/ExchangeRateData.java
@@ -1,0 +1,21 @@
+package com.wanderpass.exchange_rate_service.exchange.infrastructure.redis;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExchangeRateData {
+    private BigDecimal rate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime fetchedAt;
+}

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/presentation/controller/ExchangeRateController.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/presentation/controller/ExchangeRateController.java
@@ -1,0 +1,26 @@
+package com.wanderpass.exchange_rate_service.exchange.presentation.controller;
+
+import com.wanderpass.exchange_rate_service.exchange.application.ExchangeService;
+import com.wanderpass.exchange_rate_service.exchange.presentation.dto.request.ConvertRequest;
+import com.wanderpass.exchange_rate_service.exchange.presentation.dto.response.ConvertResponse;
+import com.wanderpass.exchange_rate_service.global.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/exchange-rates")
+@RequiredArgsConstructor
+public class ExchangeRateController {
+
+    private final ExchangeService exchangeService;
+
+    @PostMapping("/convert")
+    public ResponseEntity<ApiResponse<?>> convert(@RequestBody ConvertRequest request) {
+        ConvertResponse response = exchangeService.convert(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/presentation/dto/request/ConvertRequest.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/presentation/dto/request/ConvertRequest.java
@@ -1,0 +1,8 @@
+package com.wanderpass.exchange_rate_service.exchange.presentation.dto.request;
+
+import com.wanderpass.exchange_rate_service.exchange.domain.type.Currency;
+
+public record ConvertRequest(String requestId,
+                             Currency fromCurrency,
+                             Currency toCurrency,
+                             Integer amount) {}

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/presentation/dto/response/ConvertResponse.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/presentation/dto/response/ConvertResponse.java
@@ -1,0 +1,27 @@
+package com.wanderpass.exchange_rate_service.exchange.presentation.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConvertResponse {
+    private String requestId;
+    private BigDecimal convertedAmount;
+    private BigDecimal rate;
+    private String fromCurrency;
+    private String toCurrency;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime fetchedAt;
+}
+
+

--- a/src/main/java/com/wanderpass/exchange_rate_service/global/config/RedisConfig.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/global/config/RedisConfig.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.wanderpass.exchange_rate_service.exchange.infrastructure.redis.ExchangeRateData;
-import com.wanderpass.exchange_rate_service.exchange.presentation.dto.response.ConvertResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;

--- a/src/main/java/com/wanderpass/exchange_rate_service/global/config/RedisConfig.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/global/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.wanderpass.exchange_rate_service.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.wanderpass.exchange_rate_service.exchange.infrastructure.redis.ExchangeRateData;
+import com.wanderpass.exchange_rate_service.exchange.presentation.dto.response.ConvertResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, ExchangeRateData> exchangeRateRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, ExchangeRateData> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(mapper));
+
+        return template;
+    }
+}

--- a/src/main/java/com/wanderpass/exchange_rate_service/global/dto/ApiResponse.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/global/dto/ApiResponse.java
@@ -1,0 +1,30 @@
+package com.wanderpass.exchange_rate_service.global.dto;
+
+
+import com.wanderpass.exchange_rate_service.global.exception.type.StatusCode;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ApiResponse<T> {
+    private final String code;
+    private final String message;
+    private final T data;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .code(StatusCode.OK.getCode())
+                .message(StatusCode.OK.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return ApiResponse.<T>builder()
+                .code(StatusCode.OK.getCode())
+                .message(message)
+                .data(data)
+                .build();
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
- #17 
- 환율 계산 API 캐시 정합성 및 직렬화 오류 수정


## 작업 내용
- **환율 계산 API (`POST /api/exchange/convert`) 구현**
  - `ConvertRequest` 요청 바디 기반으로 환율 계산 및 응답 반환
  - 금액 환산 로직에서 `ExchangeRateData` 기준으로 `convertedAmount` 계산
- Redis에 저장되는 ExchangeRateData를 Jackson 기반으로 직렬화 가능하도록 설정 (GenericJackson2JsonRedisSerializer + JavaTimeModule)
- RedisTemplate<String, ExchangeRateData>를 명시적으로 Bean 등록하여 DI 문제 해결
- 기존 수동 ObjectMapper.writeValueAsString 방식 제거, 객체 기반 저장으로 통합
- LocalDateTime 직렬화 오류 해결을 위한 RedisConfig 수정
- 캐시 TTL 설정 상수 처리
- JPA에서 findTopByFromCurrencyAndToCurrencyOrderByFetchedAtDesc를 사용해 환율 중복 결과 방지 및 최신 데이터 조회
- Redis 조회 실패 시 fallback to DB → 캐시 재적재 구조 구현

## 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 자유롭게 작성해주세요. -->
<!-- 예: 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 참고 자료 (선택)
- [Jackson LocalDateTime 직렬화 공식 가이드](https://github.com/FasterXML/jackson-modules-java8)
- [Spring Data Redis: Custom RedisTemplate 설정](https://docs.spring.io/spring-data/redis/docs/current/reference/html/#redis:template)
- [RESTful API 설계 가이드 – POST vs GET](https://restfulapi.net/http-methods/)
