### PR TITLE
[Fix] 레디스에서 조회한 데이터의 객체 캐스팅 실패하는 문제 해결

### DIFF
--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/application/ExchangeService.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/application/ExchangeService.java
@@ -27,11 +27,12 @@ public class ExchangeService {
     public ConvertResponse convert(ConvertRequest request) {
         Currency from = request.fromCurrency();
         Currency to = request.toCurrency();
-
+        log.info("Converting {} to {}", from, to);
         ExchangeRateData cached = exchangeRateCacheRepository.get(from, to);
 
         // fallback 처리를 위해서 null 반환을 처리해줘야한다.
         if (cached == null) {
+            log.info("Exchange rate from {} to {} not found", from, to);
             ExchangeRate rate = exchangeRateRepository
                     .findTopByFromCurrencyAndToCurrencyOrderByFetchedAtDesc(from, to)
                     .orElseThrow(() ->

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/client/ExchangeRateClient.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/client/ExchangeRateClient.java
@@ -1,7 +1,7 @@
 package com.wanderpass.exchange_rate_service.exchange.infrastructure.client;
 
 import com.wanderpass.exchange_rate_service.exchange.application.dto.ExchangeRateResponse;
-import com.wanderpass.exchange_rate_service.exchange.config.OpenExchangeProperties;
+import com.wanderpass.exchange_rate_service.exchange.infrastructure.client.config.OpenExchangeProperties;
 import com.wanderpass.exchange_rate_service.exchange.exception.exchange.ExchangeRateApiException;
 import com.wanderpass.exchange_rate_service.global.exception.type.StatusCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/client/config/OpenExchangeProperties.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/infrastructure/client/config/OpenExchangeProperties.java
@@ -1,4 +1,4 @@
-package com.wanderpass.exchange_rate_service.exchange.config;
+package com.wanderpass.exchange_rate_service.exchange.infrastructure.client.config;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/presentation/controller/ExchangeRateController.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/presentation/controller/ExchangeRateController.java
@@ -19,7 +19,7 @@ public class ExchangeRateController {
     private final ExchangeService exchangeService;
 
     @PostMapping("/convert")
-    public ResponseEntity<ApiResponse<?>> convert(@RequestBody ConvertRequest request) {
+    public ResponseEntity<ApiResponse<ConvertResponse>> convert(@RequestBody ConvertRequest request) {
         ConvertResponse response = exchangeService.convert(request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/wanderpass/exchange_rate_service/exchange/scheduler/ExchangeRateScheduler.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/exchange/scheduler/ExchangeRateScheduler.java
@@ -18,10 +18,7 @@ public class ExchangeRateScheduler {
     private final AtomicInteger failureCount = new AtomicInteger(0);
     private static final int MAX_CONSECUTIVE_FAILURES = 3;
 
-    /**
-     * 매시 5분에 환율 동기화 실행
-     */
-    @Scheduled(cron = "0 5 * * * *")
+    @Scheduled(cron = "${schedule.exchange-rate.cron}")
     public void syncExchangeRatesHourly() {
         String startTime = LocalDateTime.now().toString();
         log.info("=== 환율 동기화 스케줄러 시작 === {}", startTime);

--- a/src/main/java/com/wanderpass/exchange_rate_service/global/config/RedisConfig.java
+++ b/src/main/java/com/wanderpass/exchange_rate_service/global/config/RedisConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -24,8 +24,11 @@ public class RedisConfig {
         mapper.registerModule(new JavaTimeModule());
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(mapper));
+        Jackson2JsonRedisSerializer<ExchangeRateData> serializer =
+                new Jackson2JsonRedisSerializer<>(mapper, ExchangeRateData.class);
 
+        template.setValueSerializer(serializer);
+        template.afterPropertiesSet();
         return template;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=exchange-rate-service
+server.port=${SERVER_PORT}
 
 # MySQL connection settings
 spring.datasource.url=${MYSQL_URL}
@@ -27,3 +28,6 @@ spring.jpa.properties.hibernate.format_sql=${DEV_JPA_FORMAT_SQL}
 # exchange api settings
 openex.base-url=${OPEN_EXCHANGE_RATES_URL}
 openex.api-key=${OPEN_EXCHANGE_RATES_API_KEY}
+
+# scheduler
+schedule.exchange-rate.cron=${OPEN_EXCHANGE_RATES_CRON}


### PR DESCRIPTION
## 연관된 이슈
- #23 

## 작업 내용
- RedisConfig.java에서 GenericJackson2JsonRedisSerializer → Jackson2JsonRedisSerializer<ExchangeRateData>로 교체하여 역직렬화 문제 해결

  - 기존 방식은 @class 메타데이터 포함으로 인해 역직렬화 시 ExchangeRateData에 알 수 없는 필드 오류 발생 가능

  - 명시적 타입 지정 방식으로 변경하여 안정적인 직렬화/역직렬화 처리

- ObjectMapper 설정은 기존과 동일하게 유지 (JavaTimeModule, WRITE_DATES_AS_TIMESTAMPS false)

- template.afterPropertiesSet() 호출 추가로 RedisTemplate 초기 설정 반영 보장

- 스케줄러 작동 시간, 서버 포트 설정을 .properties에서 환경 변수로 분리하여 외부 설정 주입 가능하도록 개선

## 변경 사항 체크리스트
- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 자유롭게 작성해주세요. -->
<!-- 예: 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## 참고 자료 (선택)
<!-- 참고한 문서, 외부 링크, 사내 위키 등 -->
<!-- 예: https://orange-peak-291.notion.site/API-219bb595ff4d80aebd00e19164ef0c53 -->
-
